### PR TITLE
Unencoded URIs ugly hack

### DIFF
--- a/IRC/plugins/URL/URL.rb
+++ b/IRC/plugins/URL/URL.rb
@@ -75,16 +75,16 @@ class URL < IRCPlugin
         uri.gsub!(/[^a-zA-Z_0-9]/) { "\\" + $& }
 
         # most fugly part: match for the extracted URI plus anything that 
-        # is not comma, blank character, period, parentheses...
-        match = /(#{uri}[^,\s.)]*)/.match(text);
+        # is not comma, blank character, period, exclamation mark, parentheses...
+        match = /(#{uri}[^\s,.)!]*)/.match(text);
         if match[0] then
             uri = match[0].to_s
         end
 
-        # shamelessly assume that an URL ending in . , ! ? 、
+        # shamelessly assume that an URL ending in . , ? 、
         # doesn't actually have that. 
         # (I never said the fugly part was the only fugly one)
-        uri.gsub!(/[.,!?、]$/, "")
+        uri.gsub!(/[.,?、]$/, "")
 
         # ')' is rarely an URI resource name so assume that the ')' in URIs
         # ending in '/)' is just an artifact from the URI having been


### PR DESCRIPTION
What's up, albel

I don't code in ruby so I have no idea if this works.
Particularly, I don't know if those horrible URIs are going to work OK on URI.parse afterwards.

I have no rubygems nor nothing, so I didn't run the bot to see if it was ok.
I just tested the uris.each do |uri| part in a little script.

Feel free to burn this code, or hack on top of it.

Cheers,
        SpiceMan
